### PR TITLE
Add support for GoodWe DT series of inverters

### DIFF
--- a/custom_components/goodwe/services.yaml
+++ b/custom_components/goodwe/services.yaml
@@ -7,7 +7,7 @@ set_work_mode:
       description: ID of the inverter entity
       example: "sensor.goodwe_inverter"
     work_mode:
-      description: 0 - General mode, 1 - Off grid mode, 2 - Backup mode
+      description: 0 - General mode, 1 - Off grid mode, 2 - Backup mode, 3 - Wait mode
       example: "0"
 set_ongrid_battery_dod:
   description: |

--- a/inverter_scan.py
+++ b/inverter_scan.py
@@ -45,7 +45,7 @@ print(f"Located inverter at IP: {result[0]}, mac: {result[1]}, name: {result[2]}
 
 # EM/ES
 try_command("AA55C07F0102000241", result[0])
-# SolarGo ?
+# DT (SolarGo)
 try_command("7F03753100280409", result[0])
 # Omnik v5 ?
 try_command("197d0001000dff045e50303036564657f6e60d", result[0])

--- a/inverter_test.py
+++ b/inverter_test.py
@@ -19,6 +19,12 @@ TIMEOUT = 2
 RETRIES = 3
 
 inverter = asyncio.run(inverter.discover(IP_ADDRESS, PORT, TIMEOUT, RETRIES))
+print(f"Identified inverter\n"
+      f"- Model: {inverter.model_name}\n"
+      f"- SerialNr: {inverter.serial_number}\n"
+      f"- Version: {inverter.software_version}"
+      )
+
 response = asyncio.run(inverter.read_runtime_data())
 
 for (sensor, _, _, unit, name, _) in inverter.sensors():


### PR DESCRIPTION
I tried to create an implementation for the DT series. As far as I can tell it is pretty similar to ET except other prefix and command codes are used. I adapted a bit the code for ET to keep as much as possible common, I renamed the EtProtocolCommand to ModbusProtocolCommand because that's what it seems to be.

I managed to find quite a lot of the sensors by comparing to SolarGo app (which works with my DT inverter), sniffing traffic and guessing (still not sure about the Running Hours since I can't view it anywhere in the app or on the device). I also managed to enable the setting of the worker mode as you can pause (I added a new mode 3 for this, only used by DT for now) and restart grid delivery with this inverter. There's no battery support here so I wasn't sure what to do with the dod functionality / HA configuration, I just put a pass in the function implementation.

Here's the output for all the sensors:

```
vpv1: 		 PV1 Voltage = 480.1 V
ipv1: 		 PV1 Current = 1.4 A
ppv1: 		 PV1 Power = 672 W
vpv2: 		 PV2 Voltage = 434.1 V
ipv2: 		 PV2 Current = 1.3 A
ppv2: 		 PV2 Power = 564 W
xx14: 		 Unknown sensor@14 = -1 
xx16: 		 Unknown sensor@16 = -1 
xx18: 		 Unknown sensor@18 = -1 
xx20: 		 Unknown sensor@20 = -1 
xx22: 		 Unknown sensor@22 = -1 
xx24: 		 Unknown sensor@24 = -1 
xx26: 		 Unknown sensor@26 = -1 
xx28: 		 Unknown sensor@28 = -1 
vline1: 		 On-grid L1-L2 Voltage = 417.5 V
vline2: 		 On-grid L2-L3 Voltage = 419.2 V
vline3: 		 On-grid L3-L1 Voltage = 417.5 V
vgrid1: 		 On-grid L1 Voltage = 242.3 V
vgrid2: 		 On-grid L2 Voltage = 241.1 V
vgrid3: 		 On-grid L3 Voltage = 240.6 V
igrid1: 		 On-grid L1 Current = 1.7 A
igrid2: 		 On-grid L2 Current = 1.7 A
igrid3: 		 On-grid L3 Current = 1.7 A
fgrid1: 		 On-grid L1 Frequency = 50.02 Hz
fgrid2: 		 On-grid L2 Frequency = 50.01 Hz
fgrid3: 		 On-grid L3 Frequency = 50.0 Hz
pgrid1: 		 On-grid L1 Power = 412 W
pgrid2: 		 On-grid L2 Power = 412 W
pgrid3: 		 On-grid L3 Power = 412 W
xx54: 		 Unknown sensor@54 = 0 
ppv: 		 PV Power = 1192 W
work_mode: 		 Work Mode code = 1 
work_mode_label: 		 Work Mode = Normal 
xx60: 		 Unknown sensor@60 = 0 
xx62: 		 Unknown sensor@62 = 0 
xx64: 		 Unknown sensor@64 = 0 
xx66: 		 Unknown sensor@66 = 0 
xx68: 		 Unknown sensor@68 = 0 
xx70: 		 Unknown sensor@70 = 0 
xx72: 		 Unknown sensor@72 = 0 
xx74: 		 Unknown sensor@74 = 0 
xx76: 		 Unknown sensor@76 = 0 
xx78: 		 Unknown sensor@78 = 0 
xx80: 		 Unknown sensor@80 = -1 
temperature: 		 Inverter Temperature = 44.2 C
xx84: 		 Unknown sensor@84 = -1 
xx86: 		 Unknown sensor@86 = -1 
e_day: 		 Today's PV Generation = 10.7 kWh
xx90: 		 Unknown sensor@90 = 0 
e_total: 		 Total PV Generation = 55.5 kWh
xx94: 		 Unknown sensor@94 = 0 
h_total: 		 Hours Total = 47 
safety_country: 		 Safety Country code = 6 
safety_country_label: 		 Safety Country = Belgium 
xx100: 		 Unknown sensor@100 = 0 
xx102: 		 Unknown sensor@102 = 0 
xx104: 		 Unknown sensor@104 = 0 
xx106: 		 Unknown sensor@106 = 0 
xx108: 		 Unknown sensor@108 = -1 
xx110: 		 Unknown sensor@110 = -1 
xx112: 		 Unknown sensor@112 = -1 
xx114: 		 Unknown sensor@114 = -1 
xx116: 		 Unknown sensor@116 = -1 
xx118: 		 Unknown sensor@118 = -1 
xx120: 		 Unknown sensor@120 = -1 
xx122: 		 Unknown sensor@122 = -1 
funbit: 		 FunBit = 512 
vbus: 		 Bus Voltage = 631.3 V
vnbus: 		 NBus Voltage = 322.1 V
xx130: 		 Unknown sensor@130 = 0 
xx132: 		 Unknown sensor@132 = 0 
xx134: 		 Unknown sensor@134 = 0 
xx136: 		 Unknown sensor@136 = 646 
xx138: 		 Unknown sensor@138 = 213 
xx140: 		 Unknown sensor@140 = 4 
xx142: 		 Unknown sensor@142 = 0 
xx144: 		 Unknown sensor@144 = 92 
```
I'm pretty sure some of these sensors contain fault information but I'm not about to put my brand new inverter through faulty situations on purpose ;-)

Just mentioning the other issues I found talking about SolarGo / DT model so they can test if they want to:
#1 #3 #11 

This was tested on a GW4K-DT model.