### PR TITLE
asyncio.exceptions seems to be not supported anymore

### DIFF
--- a/custom_components/goodwe/goodwe_inverter.py
+++ b/custom_components/goodwe/goodwe_inverter.py
@@ -394,7 +394,7 @@ class ProtocolCommand:
                 raise InverterError(
                     "No response received to '" + self.request.hex() + "' request"
                 )
-        except asyncio.exceptions.CancelledError:
+        except asyncio.CancelledError:
             raise InverterError(
                 "No valid response received to '" + self.request.hex() + "' request"
             ) from None
@@ -628,7 +628,7 @@ async def search_inverters() -> bytes:
             return result
         else:
             raise InverterError("No response received to broadcast request")
-    except asyncio.exceptions.CancelledError:
+    except asyncio.CancelledError:
         raise InverterError("No valid response received to broadcast request") from None
     finally:
         transport.close()


### PR DESCRIPTION
I am running python v3.7.3 and it seems that asyncio.exceptions.* has been replaced by asyncio.* thus causing an error when running the inverter_test script