### PR TITLE
Tentative support of EH series of inverters

### DIFF
--- a/custom_components/goodwe/goodwe_inverter.py
+++ b/custom_components/goodwe/goodwe_inverter.py
@@ -650,6 +650,11 @@ async def discover(host: str, port: int = 8899, timeout: int = 2, retries: int =
             software_version = response[71:83].decode("ascii").strip()
             _LOGGER.debug("Detected ET inverter %s, S/N:%s", model_name, serial_number)
             return ET(host, port, timeout, retries, model_name, serial_number, software_version)
+        elif "EHU" in serial_number:
+            # EH series of inverter seems to use ET protocol
+            _LOGGER.debug("Detected EH inverter %s, S/N:%s", model_name, serial_number)
+            software_version = response[71:83].decode("ascii").strip() + " <TO BE CONFIRMED>"   # TO BE CONFIRMED
+            return ET(host, port, timeout, retries, model_name, serial_number, software_version)
         else:
             software_version = response[58:70].decode("ascii").strip()
             # arm_version = response[71:83].decode("ascii").strip()


### PR DESCRIPTION
I have a new EH inverter and it seems I can connect quite well with it using the same protocol as the ET series.
By extending detection of the model on the serial number (containing "EHU"), I have good communication results.

I am not using Home Assistant so that I only use the Python class.