### PR TITLE
Added battery charge/discharge limits as inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Use at own risk.
 - Integration configuration parameters `Scan iterval`, `Network retry attempts`, `Network request timeout`.
 - Synchronize inverter clock button
 - Special work modes `Eco charge mode` and `Eco discharge mode`.
+- Battery charge and discharge limits writable
 
 ### Migration from HACS to HA
 

--- a/custom_components/goodwe/number.py
+++ b/custom_components/goodwe/number.py
@@ -56,7 +56,7 @@ NUMBERS = (
         getter=lambda inv: inv.read_setting('battery_charge_current'),
         setter=lambda inv, val: inv.inverter.write_setting('battery_charge_current', val),
         step=1,
-        min_value=1,
+        min_value=0,
         max_value=50,
     ),
     GoodweNumberEntityDescription(
@@ -68,7 +68,7 @@ NUMBERS = (
         getter=lambda inv: inv.read_setting('battery_discharge_current'),
         setter=lambda inv, val: inv.inverter.write_setting('battery_discharge_current', val),
         step=1,
-        min_value=1,
+        min_value=0,
         max_value=50,
     ),
     GoodweNumberEntityDescription(

--- a/custom_components/goodwe/number.py
+++ b/custom_components/goodwe/number.py
@@ -9,7 +9,7 @@ from goodwe import Inverter, InverterError
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, POWER_WATT
+from homeassistant.const import PERCENTAGE, POWER_WATT, ELECTRIC_CURRENT_AMPERE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -47,6 +47,30 @@ async def _set_eco_mode_power(entity: InverterNumberEntity, value: int) -> None:
 
 
 NUMBERS = (
+    GoodweNumberEntityDescription(
+        key="battery_charge_limit",
+        name="Battery charge limit",
+        icon="mdi:battery-charging",
+        entity_category=EntityCategory.CONFIG,
+        unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
+        getter=lambda inv: inv.read_setting('battery_charge_current'),
+        setter=lambda inv, val: inv.inverter.write_setting('battery_charge_current', val),
+        step=1,
+        min_value=1,
+        max_value=50,
+    ),
+    GoodweNumberEntityDescription(
+        key="battery_discharge_limit",
+        name="Battery discharge limit",
+        icon="mdi:battery-charging",
+        entity_category=EntityCategory.CONFIG,
+        unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
+        getter=lambda inv: inv.read_setting('battery_discharge_current'),
+        setter=lambda inv, val: inv.inverter.write_setting('battery_discharge_current', val),
+        step=1,
+        min_value=1,
+        max_value=50,
+    ),
     GoodweNumberEntityDescription(
         key="grid_export_limit",
         name="Grid export limit",

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "GoodWe Inverter (experimental)",
+  "name": "GoodWe Inverter (experimental, added battery limits)",
   "country": "SK",
   "domains": ["button", "number", "select", "sensor"],
   "homeassistant": "2022.4.0"

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "GoodWe Inverter (new experimental)",
+  "name": "GoodWe Inverter (experimental)",
   "country": "SK",
   "domains": ["button", "number", "select", "sensor"],
   "homeassistant": "2022.4.0"

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "GoodWe Inverter (experimental)",
+  "name": "GoodWe Inverter (new experimental)",
   "country": "SK",
   "domains": ["button", "number", "select", "sensor"],
   "homeassistant": "2022.4.0"

--- a/info.md
+++ b/info.md
@@ -12,6 +12,7 @@ Use at own risk.
 - Integration configuration parameters `Scan iterval`, `Network retry attempts`, `Network request timeout`.
 - Synchronize inverter clock button
 - Special work modes `Eco charge mode` and `Eco discharge mode`.
+- Battery charge and discharge limits writable
 
 ### Migration from HACS to HA
 


### PR DESCRIPTION
Hi there,
based on my question https://github.com/mletenay/home-assistant-goodwe-inverter/issues/120 I added 2 more numeric inputs: battery charge limit and battery discharge limit. With these you can limit the battery charge/discharge amperes. They can be used to limit the charge of the battery in the morning if the forecast shows that the 70% limit will be hit mid-day.
Please let me know if there is anything missing :)