### PR TITLE
Support for explicit inverter family

### DIFF
--- a/custom_components/goodwe/config_flow.py
+++ b/custom_components/goodwe/config_flow.py
@@ -26,6 +26,9 @@ from .const import (
 CONFIG_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
+        vol.Required(CONF_MODEL_FAMILY,
+                        default="none"
+        ): str,
     }
 )
 
@@ -88,9 +91,10 @@ class GoodweFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
         if user_input is not None:
             host = user_input[CONF_HOST]
+            model_family = user_input[CONF_MODEL_FAMILY]
 
             try:
-                inverter = await connect(host=host, retries=10)
+                inverter = await connect(host=host, family=model_family, retries=10)
             except InverterError:
                 errors[CONF_HOST] = "connection_error"
             else:

--- a/custom_components/goodwe/strings.json
+++ b/custom_components/goodwe/strings.json
@@ -5,7 +5,8 @@
         "title": "GoodWe inverter",
         "description": "Connect to inverter",
         "data": {
-          "host": "[%key:common::config_flow::data::ip%]"
+          "host": "[%key:common::config_flow::data::ip%]",
+          "model_family": "Inverter Family (optional)"
         }
       }
     },

--- a/custom_components/goodwe/translations/en.json
+++ b/custom_components/goodwe/translations/en.json
@@ -11,7 +11,8 @@
         "step": {
             "user": {
                 "data": {
-                    "host": "IP Address"
+                    "host": "IP Address",
+                    "model_family": "Inverter Family (optional)"
                 },
                 "description": "Connect to inverter",
                 "title": "GoodWe inverter"


### PR DESCRIPTION
I've just had a GW5000D-NS installed and the AA55 initial command results in my wifi module disconnecting from the inverter/network which requires a full inverter restart to recover from

This PR is to add the option in to allow to define the inverter family via the GUI to skip the discovery step