### PR TITLE
Backup supply switch

### DIFF
--- a/custom_components/goodwe/icons.json
+++ b/custom_components/goodwe/icons.json
@@ -57,6 +57,13 @@
           "on": "mdi:battery-arrow-up",
           "off": "mdi:battery-medium"
         }
+      },
+      "backup_supply_switch": {
+        "default": "mdi:battery-medium",
+        "state": {
+          "on": "mdi:battery-medium",
+          "off": "mdi:battery-medium"
+        }
       }
     }
   }

--- a/custom_components/goodwe/strings.json
+++ b/custom_components/goodwe/strings.json
@@ -74,6 +74,9 @@
       },
       "load_control": {
         "name": "Load control"
+      },
+      "backup_supply_switch": {
+        "name": "Backup supply switch"
       }
     }
   },

--- a/custom_components/goodwe/switch.py
+++ b/custom_components/goodwe/switch.py
@@ -51,6 +51,13 @@ SWITCHES = (
         setting="fast_charging",
         polling_interval=30,
     ),
+    GoodweSwitchEntityDescription(
+        key="backup_supply_switch",
+        translation_key="backup_supply_switch",
+        entity_category=EntityCategory.CONFIG,
+        device_class=SwitchDeviceClass.SWITCH,
+        setting="backup_supply",
+    ),
 )
 
 

--- a/custom_components/goodwe/translations/cs.json
+++ b/custom_components/goodwe/translations/cs.json
@@ -86,6 +86,9 @@
               },
             "load_control": {
                 "name": "Řízení zátěže"
+            },
+            "backup_supply_switch": {
+                "name": "Záloha"
             }
         }
     },

--- a/custom_components/goodwe/translations/en.json
+++ b/custom_components/goodwe/translations/en.json
@@ -85,6 +85,9 @@
               },
             "load_control": {
                 "name": "Load control"
+            },
+            "backup_supply_switch": {
+                "name": "Backup supply"
             }
         }
     },


### PR DESCRIPTION
To my observations backup supply consumes constantly about 30W on GW10ET, therefore is useful to automate its on/off state.