### PR TITLE
allow configuring inverter modbus id

### DIFF
--- a/custom_components/goodwe/__init__.py
+++ b/custom_components/goodwe/__init__.py
@@ -12,8 +12,10 @@ from .const import (
     CONF_MODEL_FAMILY,
     CONF_NETWORK_RETRIES,
     CONF_NETWORK_TIMEOUT,
+    CONF_MODBUS_ID,
     DEFAULT_NETWORK_RETRIES,
     DEFAULT_NETWORK_TIMEOUT,
+    DEFAULT_MODBUS_ID,
     DOMAIN,
     KEY_COORDINATOR,
     KEY_DEVICE_INFO,
@@ -33,6 +35,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     model_family = entry.options.get(CONF_MODEL_FAMILY, entry.data[CONF_MODEL_FAMILY])
     network_retries = entry.options.get(CONF_NETWORK_RETRIES, DEFAULT_NETWORK_RETRIES)
     network_timeout = entry.options.get(CONF_NETWORK_TIMEOUT, DEFAULT_NETWORK_TIMEOUT)
+    modbus_id = entry.options.get(CONF_MODBUS_ID, DEFAULT_MODBUS_ID)
 
     # Connect to Goodwe inverter
     try:
@@ -40,7 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             host=host,
             port=502 if protocol == "TCP" else 8899,
             family=model_family,
-            comm_addr=0,
+            comm_addr=modbus_id,
             timeout=network_timeout,
             retries=network_retries,
         )

--- a/custom_components/goodwe/config_flow.py
+++ b/custom_components/goodwe/config_flow.py
@@ -18,9 +18,11 @@ from .const import (
     CONF_MODEL_FAMILY,
     CONF_NETWORK_RETRIES,
     CONF_NETWORK_TIMEOUT,
+    CONF_MODBUS_ID,
     DEFAULT_NAME,
     DEFAULT_NETWORK_RETRIES,
     DEFAULT_NETWORK_TIMEOUT,
+    DEFAULT_MODBUS_ID,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
@@ -40,6 +42,7 @@ OPTIONS_SCHEMA = vol.Schema(
         vol.Required(CONF_KEEP_ALIVE): cv.boolean,
         vol.Required(CONF_MODEL_FAMILY): str,
         vol.Optional(CONF_SCAN_INTERVAL): int,
+        vol.Optional(CONF_MODBUS_ID): int,
         vol.Optional(CONF_NETWORK_RETRIES): cv.positive_int,
         vol.Optional(CONF_NETWORK_TIMEOUT): cv.positive_int,
     }
@@ -74,6 +77,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         network_timeout = self.entry.options.get(
             CONF_NETWORK_TIMEOUT, DEFAULT_NETWORK_TIMEOUT
         )
+        modbus_id = self.entry.options.get(
+            CONF_MODBUS_ID, DEFAULT_MODBUS_ID
+        )
 
         return self.async_show_form(
             step_id="init",
@@ -89,6 +95,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     ),
                     CONF_NETWORK_RETRIES: network_retries,
                     CONF_NETWORK_TIMEOUT: network_timeout,
+                    CONF_MODBUS_ID: modbus_id,
                 },
             ),
         )

--- a/custom_components/goodwe/const.py
+++ b/custom_components/goodwe/const.py
@@ -19,11 +19,13 @@ SCAN_INTERVAL = timedelta(seconds=10)
 DEFAULT_SCAN_INTERVAL = 5
 DEFAULT_NETWORK_RETRIES = 10
 DEFAULT_NETWORK_TIMEOUT = 1
+DEFAULT_MODBUS_ID = 0
 
 CONF_KEEP_ALIVE = "keep_alive"
 CONF_MODEL_FAMILY = "model_family"
 CONF_NETWORK_RETRIES = "network_retries"
 CONF_NETWORK_TIMEOUT = "network_timeout"
+CONF_MODBUS_ID = "modbus_id"
 
 KEY_INVERTER = "inverter"
 KEY_COORDINATOR = "coordinator"


### PR DESCRIPTION
Modbus id can now be configured to a value different to the default 247, this allows accessing multiple inverters connected to a single controller. 