### PR TITLE
DOD holding and offline battery DOD  settings added

### DIFF
--- a/custom_components/goodwe/icons.json
+++ b/custom_components/goodwe/icons.json
@@ -18,6 +18,9 @@
       "battery_discharge_depth": {
         "default": "mdi:battery-arrow-down"
       },
+      "battery_discharge_depth_offline": {
+        "default": "mdi:battery-arrow-down"
+      },
       "eco_mode_power": {
         "default": "mdi:battery-charging-low"
       },
@@ -63,6 +66,13 @@
         "state": {
           "on": "mdi:battery-medium",
           "off": "mdi:battery-medium"
+        }
+      },
+      "dod_holding_switch": {
+        "default": "mdi:battery-arrow-down",
+        "state": {
+          "on": "mdi:battery-arrow-down",
+          "off": "mdi:battery-arrow-down"
         }
       }
     }

--- a/custom_components/goodwe/number.py
+++ b/custom_components/goodwe/number.py
@@ -38,6 +38,16 @@ def _get_setting_unit(inverter: Inverter, setting: str) -> str:
     return next((s.unit for s in inverter.settings() if s.id_ == setting), "")
 
 
+async def set_offline_battery_dod(inverter: Inverter, dod: int) -> None:
+    """Sets offline battery dod - dod for backup output"""
+    if 10 <= dod <= 100:
+        await inverter.write_setting('battery_discharge_depth_offline', 100 - dod)
+
+
+async def get_offline_battery_dod(inverter: Inverter) -> int:
+    """Returns offline battery dod - dod for backup output"""
+    return 100 - (await inverter.read_setting('battery_discharge_depth_offline'))
+
 NUMBERS = (
     # Only one of the export limits are added.
     # Availability is checked in the filter method.
@@ -80,6 +90,19 @@ NUMBERS = (
         getter=lambda inv: inv.get_ongrid_battery_dod(),
         mapper=lambda v: v,
         setter=lambda inv, val: inv.set_ongrid_battery_dod(val),
+        filter=lambda inv: True,
+    ),
+    GoodweNumberEntityDescription(
+        key="battery_discharge_depth_offline",
+        translation_key="battery_discharge_depth_offline",
+        entity_category=EntityCategory.CONFIG,
+        native_unit_of_measurement=PERCENTAGE,
+        native_step=1,
+        native_min_value=0,
+        native_max_value=99,
+        getter=lambda inv: get_offline_battery_dod(inv),
+        mapper=lambda v: v,
+        setter=lambda inv, val: set_offline_battery_dod(inv, val),
         filter=lambda inv: True,
     ),
     GoodweNumberEntityDescription(

--- a/custom_components/goodwe/strings.json
+++ b/custom_components/goodwe/strings.json
@@ -44,6 +44,9 @@
       "battery_discharge_depth": {
         "name": "Depth of discharge (on-grid)"
       },
+      "battery_discharge_depth_offline": {
+        "name": "Depth of discharge (backup)"
+      },
       "fast_charging_power": {
         "name": "Fast charging power"
       },
@@ -77,6 +80,9 @@
       },
       "backup_supply_switch": {
         "name": "Backup supply switch"
+      },
+      "dod_holding_switch": {
+        "name": "DOD holding"
       }
     }
   },

--- a/custom_components/goodwe/switch.py
+++ b/custom_components/goodwe/switch.py
@@ -58,6 +58,13 @@ SWITCHES = (
         device_class=SwitchDeviceClass.SWITCH,
         setting="backup_supply",
     ),
+    GoodweSwitchEntityDescription(
+        key="dod_holding_switch",
+        translation_key="dod_holding_switch",
+        entity_category=EntityCategory.CONFIG,
+        device_class=SwitchDeviceClass.SWITCH,
+        setting="dod_holding",
+    ),
 )
 
 

--- a/custom_components/goodwe/translations/cs.json
+++ b/custom_components/goodwe/translations/cs.json
@@ -36,6 +36,9 @@
             "battery_discharge_depth": {
                 "name": "Maximum vybití (v síti)"
             },
+            "battery_discharge_depth_offline": {
+                "name": "Maximum vybití (backup)"
+            },
             "eco_mode_power": {
                 "name": "Výkon v ekonomickém režimu"
             },
@@ -89,6 +92,9 @@
             },
             "backup_supply_switch": {
                 "name": "Záloha"
+            },
+            "dod_holding_switch": {
+                "name": "Udržovat DOD baterie"
             }
         }
     },

--- a/custom_components/goodwe/translations/en.json
+++ b/custom_components/goodwe/translations/en.json
@@ -36,6 +36,9 @@
             "battery_discharge_depth": {
                 "name": "Depth of discharge (on-grid)"
             },
+            "battery_discharge_depth_offline": {
+                "name": "Depth of discharge (backup)"
+            },
             "eco_mode_power": {
                 "name": "Eco mode power"
             },
@@ -88,6 +91,9 @@
             },
             "backup_supply_switch": {
                 "name": "Backup supply"
+            },
+            "dod_holding_switch": {
+                "name": "DOD holding"
             }
         }
     },


### PR DESCRIPTION
Added additional settings which are useful for islands. Been using it on GW10ET:

- `battery_discharge_depth_offline`- sets maximum battery dod, when running on backup supply
- `dod_holding_switch` tells the inverter to charge battery if dod falls under desired limit (`battery_discharge_depth_offline` or `battery_discharge_depth`)
