### PR TITLE
Additional options for DT Series

### DIFF
--- a/custom_components/goodwe/button.py
+++ b/custom_components/goodwe/button.py
@@ -46,6 +46,12 @@ BUTTONS = (
         setting="stop",
         action=lambda inv: inv.write_setting("stop", 0),
     ),
+    GoodweButtonEntityDescription(
+        key="restart_inverter",
+        translation_key="restart_inverter",
+        setting="restart",
+        action=lambda inv: inv.write_setting("restart", 0),
+    ),
 )
 
 

--- a/custom_components/goodwe/icons.json
+++ b/custom_components/goodwe/icons.json
@@ -9,6 +9,9 @@
       },
       "stop_inverter": {
         "default": "mdi:power-off"
+      },
+      "restart_inverter": {
+        "default": "mdi:restart"
       }
     },
     "number": {
@@ -29,6 +32,9 @@
       },
       "fast_charging_soc": {
         "default": "mdi:battery-arrow-up"
+      },
+      "shadow_scan_time": {
+        "default": "mdi:weather-cloudy-clock"
       }
     },
     "select": {
@@ -63,6 +69,27 @@
         "state": {
           "on": "mdi:battery-medium",
           "off": "mdi:battery-medium"
+        }
+      },
+      "shadow_scan_pv1": {
+        "default": "mdi:cloud",
+        "state": {
+          "on": "mdi:cloud-check",
+          "off": "mdi:cloud-cancel-outline"
+        }
+      },
+      "shadow_scan_pv2": {
+        "default": "mdi:cloud",
+        "state": {
+          "on": "mdi:cloud-check",
+          "off": "mdi:cloud-cancel-outline"
+        }
+      },
+      "shadow_scan_pv3": {
+        "default": "mdi:cloud",
+        "state": {
+          "on": "mdi:cloud-check",
+          "off": "mdi:cloud-cancel-outline"
         }
       }
     }

--- a/custom_components/goodwe/number.py
+++ b/custom_components/goodwe/number.py
@@ -12,7 +12,7 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
 )
-from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfPower
+from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfPower, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -131,6 +131,20 @@ NUMBERS = (
         getter=lambda inv: inv.read_setting("fast_charging_soc"),
         mapper=lambda v: v,
         setter=lambda inv, val: inv.write_setting("fast_charging_soc", val),
+        filter=lambda inv: True,
+    ),
+    GoodweNumberEntityDescription(
+        key="shadow_scan_time",
+        translation_key="shadow_scan_time",
+        entity_category=EntityCategory.CONFIG,
+        device_class=NumberDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        native_step=5,
+        native_max_value=300,
+        native_min_value=5,
+        getter=lambda inv: inv.read_setting("shadow_scan_time"),
+        mapper=lambda v: v,
+        setter=lambda inv, val: inv.write_setting("shadow_scan_time", val),
         filter=lambda inv: True,
     ),
 )

--- a/custom_components/goodwe/sensor.py
+++ b/custom_components/goodwe/sensor.py
@@ -65,6 +65,7 @@ _MAIN_SENSORS = (
     "ppv",
     "house_consumption",
     "active_power",
+    "meter_active_power",
     "battery_soc",
     "e_day",
     "e_total",
@@ -101,6 +102,12 @@ _DESCRIPTIONS: dict[str, GoodweSensorEntityDescription] = {
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+    ),
+    "mA": GoodweSensorEntityDescription(
+        key="mA",
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.MILLIAMPERE,
     ),
     "V": GoodweSensorEntityDescription(
         key="V",

--- a/custom_components/goodwe/strings.json
+++ b/custom_components/goodwe/strings.json
@@ -29,6 +29,9 @@
       },
       "stop_inverter": {
         "name": "Stop inverter"
+      },
+      "restart_inverter": {
+        "name": "Restart inverter"
       }
     },
     "number": {
@@ -49,6 +52,9 @@
       },
       "fast_charging_soc": {
         "name": "Fast charging SoC"
+      },
+      "shadow_scan_time": {
+        "name": "Shadow Scan Time"
       }
     },
     "select": {
@@ -77,6 +83,15 @@
       },
       "backup_supply_switch": {
         "name": "Backup supply switch"
+      },
+      "shadow_scan_pv1_switch": {
+        "name": "Shadow Scan PV1 switch"
+      },
+      "shadow_scan_pv2_switch": {
+        "name": "Shadow Scan PV2 switch"
+      },
+      "shadow_scan_pv3_switch": {
+        "name": "Shadow Scan PV3 switch"
       }
     }
   },

--- a/custom_components/goodwe/switch.py
+++ b/custom_components/goodwe/switch.py
@@ -57,6 +57,27 @@ SWITCHES = (
         device_class=SwitchDeviceClass.SWITCH,
         setting="backup_supply",
     ),
+    GoodweSwitchEntityDescription(
+        key="shadow_scan_pv1",
+        translation_key="shadow_scan_pv1",
+        entity_category=EntityCategory.CONFIG,
+        device_class=SwitchDeviceClass.SWITCH,
+        setting="shadow_scan_pv1",
+    ),
+    GoodweSwitchEntityDescription(
+        key="shadow_scan_pv2",
+        translation_key="shadow_scan_pv2",
+        entity_category=EntityCategory.CONFIG,
+        device_class=SwitchDeviceClass.SWITCH,
+        setting="shadow_scan_pv2",
+    ),
+    GoodweSwitchEntityDescription(
+        key="shadow_scan_pv3",
+        translation_key="shadow_scan_pv3",
+        entity_category=EntityCategory.CONFIG,
+        device_class=SwitchDeviceClass.SWITCH,
+        setting="shadow_scan_pv3",
+    ),
 )
 
 

--- a/custom_components/goodwe/translations/en.json
+++ b/custom_components/goodwe/translations/en.json
@@ -30,6 +30,9 @@
             },
             "stop_inverter": {
                 "name": "Stop inverter"
+            },
+            "restart_inverter": {
+                "name": "Restart inverter"
             }
         },
         "number": {
@@ -48,8 +51,11 @@
             "fast_charging_power": {
                 "name": "Fast charging power"
             },
-              "fast_charging_soc": {
+            "fast_charging_soc": {
                 "name": "Fast charging SoC"
+            },
+            "shadow_scan_time": {
+                "name": "Shadow Scan Time"
             }
         },
         "select": {
@@ -88,6 +94,15 @@
             },
             "backup_supply_switch": {
                 "name": "Backup supply"
+            },
+            "shadow_scan_pv1": {
+                "name": "Shadow Scan PV1 switch"
+            },
+            "shadow_scan_pv2": {
+                "name": "Shadow Scan PV2 switch"
+            },
+            "shadow_scan_pv3": {
+                "name": "Shadow Scan PV3 switch"
             }
         }
     },


### PR DESCRIPTION
Linked to https://github.com/marcelblijleven/goodwe/pull/115

- Add Button to Restart Inverter, with associated icon, string, english title.
- Add Number to configure Shadow Scan Time / Duration using 'UnitOfTime' measurement, with associated icon, string, english title.
- Add Sensor 'meter_active_power' to _MAIN_SENSORS to allow for GM1000 series Smart Meter data.
- Add Sensor Entity Description "mA" using UnitOfElectricCurrent Milliampere for Leakage Current.
- Add 3x Switch entries for Shadow Scan PV1/PV2/PV3, with associated icon, string, english title.

Unsure whether this is a 'breaking change' if accepted before an update to the PyPi library. If so, the requirements line of manifest.json will need to be updated.