### PR TITLE
add dynamic port definition for Modbus TCP

### DIFF
--- a/custom_components/goodwe/__init__.py
+++ b/custom_components/goodwe/__init__.py
@@ -1,6 +1,7 @@
 """The Goodwe inverter component."""
 
 from goodwe import InverterError, connect
+import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PROTOCOL, CONF_PORT
 from homeassistant.core import HomeAssistant
@@ -21,6 +22,8 @@ from .const import (
 )
 from .coordinator import GoodweConfigEntry, GoodweRuntimeData, GoodweUpdateCoordinator
 from .services import async_setup_services, async_unload_services
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: GoodweConfigEntry) -> bool:
@@ -46,6 +49,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: GoodweConfigEntry) -> bo
 
     # Connect to Goodwe inverter
     try:
+        import inspect
+
+        mod = inspect.getmodule(connect)
+        if mod is not None and getattr(mod, "__file__", None):
+            _LOGGER.debug("goodwe module file (via connect): %s", mod.__file__)
+        else:
+            try:
+                import goodwe
+                _LOGGER.debug("goodwe module file (import): %s", getattr(goodwe, "__file__", None))
+            except Exception as err:
+                _LOGGER.debug("goodwe module not found: %s", err)
+
+        _LOGGER.debug("Goodwe connecting to %s:%s protocol=%s family=%s", host, port, protocol, model_family)
+
         inverter = await connect(
             host=host,
             port=port,

--- a/custom_components/goodwe/__init__.py
+++ b/custom_components/goodwe/__init__.py
@@ -34,11 +34,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: GoodweConfigEntry) -> bo
     network_timeout = entry.options.get(CONF_NETWORK_TIMEOUT, DEFAULT_NETWORK_TIMEOUT)
     modbus_id = entry.options.get(CONF_MODBUS_ID, DEFAULT_MODBUS_ID)
 
+    # Determine port: options -> data -> protocol default
+    port = entry.options.get("port", entry.data.get("port"))
+    if port is None:
+        port = 502 if protocol == "TCP" else 8899
+
     # Connect to Goodwe inverter
     try:
         inverter = await connect(
             host=host,
-            port=502 if protocol == "TCP" else 8899,
+            port=port,
             family=model_family,
             comm_addr=modbus_id,
             timeout=network_timeout,

--- a/custom_components/goodwe/config_flow.py
+++ b/custom_components/goodwe/config_flow.py
@@ -133,9 +133,14 @@ class GoodweFlowHandler(ConfigFlow, domain=DOMAIN):
             host = user_input[CONF_HOST]
             protocol = user_input[CONF_PROTOCOL]
             model_family = user_input[CONF_MODEL_FAMILY]
-            port = user_input.get(CONF_PORT)
-            if port is None:
-                port = 502 if protocol == "TCP" else 8899
+            # If protocol is UDP, always use 8899. For TCP prefer user-specified port,
+            # otherwise fall back to 502.
+            if protocol == "UDP":
+                port = 8899
+            elif protocol == "TCP":
+                port = user_input.get(CONF_PORT) or 502
+            else:
+                port = user_input.get(CONF_PORT)
 
             try:
                 inverter = await connect(

--- a/custom_components/goodwe/config_flow.py
+++ b/custom_components/goodwe/config_flow.py
@@ -37,8 +37,8 @@ PROTOCOL_CHOICES = ["UDP", "ModBus TCP"]
 CONFIG_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
-        vol.Required(CONF_PROTOCOL, default="UDP"): vol.In(PROTOCOL_CHOICES),
         vol.Optional(CONF_PORT): int,
+        vol.Required(CONF_PROTOCOL, default="UDP"): vol.In(PROTOCOL_CHOICES),
         vol.Required(CONF_MODEL_FAMILY, default="none"): str,
     }
 )

--- a/custom_components/goodwe/config_flow.py
+++ b/custom_components/goodwe/config_flow.py
@@ -33,7 +33,7 @@ from .const import (
     DOMAIN,
 )
 
-PROTOCOL_CHOICES = ["UDP", "TCP"]
+PROTOCOL_CHOICES = ["UDP", "ModBus TCP"]
 CONFIG_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
@@ -45,8 +45,8 @@ CONFIG_SCHEMA = vol.Schema(
 OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
-        vol.Required(CONF_PROTOCOL): vol.In(PROTOCOL_CHOICES),
         vol.Optional(CONF_PORT): int,
+        vol.Required(CONF_PROTOCOL): vol.In(PROTOCOL_CHOICES),
         vol.Required(CONF_KEEP_ALIVE): cv.boolean,
         vol.Required(CONF_MODEL_FAMILY): str,
         vol.Optional(CONF_SCAN_INTERVAL): int,
@@ -96,8 +96,8 @@ class OptionsFlowHandler(OptionsFlow):
                 OPTIONS_SCHEMA,
                 {
                     CONF_HOST: host,
+                    CONF_PORT: port,
                     CONF_PROTOCOL: protocol,
-                        CONF_PORT: port,
                     CONF_KEEP_ALIVE: keep_alive,
                     CONF_MODEL_FAMILY: model_family,
                     CONF_SCAN_INTERVAL: self.entry.options.get(
@@ -137,12 +137,13 @@ class GoodweFlowHandler(ConfigFlow, domain=DOMAIN):
             # otherwise fall back to 502.
             if protocol == "UDP":
                 port = 8899
-            elif protocol == "TCP":
+            elif protocol == "ModBus TCP":
                 port = user_input.get(CONF_PORT) or 502
             else:
                 port = user_input.get(CONF_PORT)
 
             try:
+                _LOGGER.debug("Goodwe connecting to %s:%s protocol=%s family=%s", host, port, protocol, model_family)
                 inverter = await connect(
                     host=host, port=port, family=model_family, retries=10
                 )

--- a/custom_components/goodwe/translations/cs.json
+++ b/custom_components/goodwe/translations/cs.json
@@ -97,6 +97,7 @@
             "init": {
                 "data": {
                     "host": "IP adresa",
+                    "port": "Port",
                     "protocol": "Protokol",
                     "keep_alive": "TCP Keep alive",
                     "model_family": "Typ protokolu [ET|DT|ES]",

--- a/custom_components/goodwe/translations/de.json
+++ b/custom_components/goodwe/translations/de.json
@@ -93,6 +93,7 @@
             "init": {
                 "data": {
                     "host": "Hostname / IP-Adresse",
+                    "port": "Port",
                     "protocol": "Protokoll",
                     "keep_alive": "TCP Aufrechterhaltung",
                     "model_family": "Protokoll Familie [ET|DT|ES]",

--- a/custom_components/goodwe/translations/en.json
+++ b/custom_components/goodwe/translations/en.json
@@ -96,6 +96,7 @@
             "init": {
                 "data": {
                     "host": "Hostname / IP Address",
+                    "port": "Port",
                     "protocol": "Protocol",
                     "keep_alive": "TCP Keep alive",
                     "model_family": "Protocol Family [ET|DT|ES]",

--- a/custom_components/goodwe/translations/sk.json
+++ b/custom_components/goodwe/translations/sk.json
@@ -97,6 +97,7 @@
             "init": {
                 "data": {
                     "host": "IP adresa",
+                    "port": "Port",
                     "protocol": "Protokol",
                     "keep_alive": "TCP Keep alive",
                     "model_family": "Typ protokolu [ET|DT|ES]",


### PR DESCRIPTION
This allows the usage of other ports than 502 for Modbus TCP. With this change, the usage of a Modbus Proxy is possible, to allow the connection of different applications to access a goodwe inverter via Modbus TCP.
UDP will always use port 8899.

In addition a change in the goodwe library (https://github.com/marcelblijleven/goodwe) is necessary. I also opened a Pull request #119 to make this small change. Could you please have a look to that?

Thank you.