### PR TITLE
Revert workaround: use direct await for async_forward_entry_setups

### DIFF
--- a/custom_components/goodwe/__init__.py
+++ b/custom_components/goodwe/__init__.py
@@ -84,7 +84,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GoodweConfigEntry) -> bo
 
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
-    await hass.async_add_executor_job(     hass.config_entries.async_forward_entry_setups, entry, PLATFORMS )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     await async_setup_services(hass)
 


### PR DESCRIPTION
Revert workaround using async_add_executor_job for async_forward_entry_setups.

- async_forward_entry_setups is already async, no need for executor.