### PR TITLE
feat: add battery_soc_protection entity for EMS mode DoD control

### DIFF
--- a/custom_components/goodwe/number.py
+++ b/custom_components/goodwe/number.py
@@ -182,6 +182,20 @@ NUMBERS = (
         setter=lambda inv, val: inv.write_setting("ems_power_limit", val),
         filter=lambda inv: True,
     ),
+    GoodweNumberEntityDescription(
+        key="battery_soc_protection",
+        translation_key="battery_soc_protection",
+        icon="mdi:battery-arrow-down-outline",
+        entity_category=EntityCategory.CONFIG,
+        native_unit_of_measurement=PERCENTAGE,
+        native_step=1,
+        native_min_value=0,
+        native_max_value=100,
+        getter=lambda inv: inv.read_setting("battery_soc_protection"),
+        mapper=lambda v: v,
+        setter=lambda inv, val: inv.write_setting("battery_soc_protection", val),
+        filter=lambda inv: True,
+    ),
 )
 
 

--- a/custom_components/goodwe/strings.json
+++ b/custom_components/goodwe/strings.json
@@ -38,6 +38,9 @@
       "eco_mode_soc": {
         "name": "Eco mode SoC"
       },
+      "battery_soc_protection": {
+        "name": "Battery SoC protection"
+      },
       "ems_power_limit": {
         "name": "EMS power limit"
       },

--- a/custom_components/goodwe/translations/en.json
+++ b/custom_components/goodwe/translations/en.json
@@ -46,6 +46,9 @@
             "eco_mode_soc": {
                 "name": "Eco mode SoC"
             },
+            "battery_soc_protection": {
+                "name": "Battery SoC protection"
+            },
             "ems_power_limit": {
                 "name": "EMS power limit"
             },


### PR DESCRIPTION
Fixes #432 

### Description
This PR exposes the `battery_soc_protection` register to resolve the issue where users lack control over the Depth of Discharge (DoD) floor while the inverter is in EMS mode.

Currently, the integration exposes `battery_discharge_depth` (register 45356). However, this is a standard on-grid/hardware configuration. When `ems_mode` is active (e.g., AUTO, DISCHARGE_BATTERY), the inverter ignores 45356 and instead strictly enforces `battery_soc_protection` as the operational SoC floor. 

### Technical Details & Justification
* **Entity Naming:** The entity key is exactly `battery_soc_protection` to mirror the upstream goodwe library setting ID verbatim, maintaining the integration's 1:1 mapping standard.
* **Scope:** While it acts as the EMS-mode floor, this is a **global** operational setting, not EMS-specific. Evidence: The ES inverter possesses a fully functional `battery_soc_protection` register (56), despite `get_ems_mode` / `set_ems_mode` raising a `NotImplementedError` on ES hardware. Furthermore, on the ET layout, 47500 sits in the general operational block (47000–47488), preceding the actual EMS registers (47511+). 
* **Multiple Battery Stacks:** Regarding the discussion in #432 about multiple stacks: Both `e_bat_charge_total` and `e_bat_discharge_total` treat the stacks as one logical battery. At the library level, `battery_soc_protection` is a single global register. Per-stack DoD control does not appear to exist in the underlying library (the `battery2_*` entries are read-only BMS telemetry). I leave it to the maintainers to verify if any further library-level updates are needed for edge-case stack setups, but this implementation aligns with the current library capabilities.
