### PR TITLE
Additional options for DT Series

### DIFF
--- a/custom_components/goodwe/button.py
+++ b/custom_components/goodwe/button.py
@@ -46,6 +46,12 @@ BUTTONS = (
         setting="stop",
         action=lambda inv: inv.write_setting("stop", 0),
     ),
+    GoodweButtonEntityDescription(
+        key="restart_inverter",
+        translation_key="restart_inverter",
+        setting="restart",
+        action=lambda inv: inv.write_setting("restart", 0),
+    ),
 )
 
 

--- a/custom_components/goodwe/icons.json
+++ b/custom_components/goodwe/icons.json
@@ -9,6 +9,9 @@
       },
       "stop_inverter": {
         "default": "mdi:power-off"
+      },
+      "restart_inverter": {
+        "default": "mdi:restart"
       }
     },
     "number": {
@@ -35,6 +38,9 @@
       },
       "soc_upper_limit": {
         "default": "mdi:battery-heart-outline"
+      },
+      "shadow_scan_time": {
+        "default": "mdi:weather-cloudy-clock"
       }
     },
     "select": {
@@ -76,6 +82,27 @@
         "state": {
           "on": "mdi:battery-arrow-down",
           "off": "mdi:battery-arrow-down"
+        }
+      },
+      "shadow_scan_pv1_switch": {
+        "default": "mdi:cloud",
+        "state": {
+          "on": "mdi:cloud-check",
+          "off": "mdi:cloud-cancel-outline"
+        }
+      },
+      "shadow_scan_pv2_switch": {
+        "default": "mdi:cloud",
+        "state": {
+          "on": "mdi:cloud-check",
+          "off": "mdi:cloud-cancel-outline"
+        }
+      },
+      "shadow_scan_pv3_switch": {
+        "default": "mdi:cloud",
+        "state": {
+          "on": "mdi:cloud-check",
+          "off": "mdi:cloud-cancel-outline"
         }
       }
     }

--- a/custom_components/goodwe/number.py
+++ b/custom_components/goodwe/number.py
@@ -12,7 +12,7 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
 )
-from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfPower
+from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfPower, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -194,6 +194,20 @@ NUMBERS = (
         getter=lambda inv: inv.read_setting("battery_soc_protection"),
         mapper=lambda v: v,
         setter=lambda inv, val: inv.write_setting("battery_soc_protection", val),
+        filter=lambda inv: True,
+    ),
+    GoodweNumberEntityDescription(
+        key="shadow_scan_time",
+        translation_key="shadow_scan_time",
+        entity_category=EntityCategory.CONFIG,
+        device_class=NumberDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        native_step=5,
+        native_max_value=300,
+        native_min_value=5,
+        getter=lambda inv: inv.read_setting("shadow_scan_time"),
+        mapper=lambda v: v,
+        setter=lambda inv, val: inv.write_setting("shadow_scan_time", val),
         filter=lambda inv: True,
     ),
 )

--- a/custom_components/goodwe/sensor.py
+++ b/custom_components/goodwe/sensor.py
@@ -65,6 +65,7 @@ _MAIN_SENSORS = (
     "ppv",
     "house_consumption",
     "active_power",
+    "meter_active_power",
     "battery_soc",
     "e_day",
     "e_total",
@@ -101,6 +102,12 @@ _DESCRIPTIONS: dict[str, GoodweSensorEntityDescription] = {
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+    ),
+    "mA": GoodweSensorEntityDescription(
+        key="mA",
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.MILLIAMPERE,
     ),
     "V": GoodweSensorEntityDescription(
         key="V",

--- a/custom_components/goodwe/strings.json
+++ b/custom_components/goodwe/strings.json
@@ -21,6 +21,15 @@
   },
   "entity": {
     "button": {
+      "restart_inverter": {
+        "name": "Restart inverter"
+      },
+      "start_inverter": {
+        "name": "Start inverter"
+      },
+      "stop_inverter": {
+        "name": "Stop inverter"
+      },
       "synchronize_clock": {
         "name": "Synchronize inverter clock"
       }
@@ -52,6 +61,9 @@
       },
       "grid_export_limit": {
         "name": "Grid export limit"
+      },
+      "shadow_scan_time": {
+        "name": "Shadow Scan Time"
       },
       "soc_upper_limit": {
         "name": "SoC upper limit"
@@ -103,6 +115,15 @@
       },
       "load_control": {
         "name": "Load control"
+      },
+      "shadow_scan_pv1_switch": {
+        "name": "Shadow Scan PV1 switch"
+      },
+      "shadow_scan_pv2_switch": {
+        "name": "Shadow Scan PV2 switch"
+      },
+      "shadow_scan_pv3_switch": {
+        "name": "Shadow Scan PV3 switch"
       }
     }
   },

--- a/custom_components/goodwe/switch.py
+++ b/custom_components/goodwe/switch.py
@@ -64,6 +64,27 @@ SWITCHES = (
         device_class=SwitchDeviceClass.SWITCH,
         setting="dod_holding",
     ),
+    GoodweSwitchEntityDescription(
+        key="shadow_scan_pv1_switch",
+        translation_key="shadow_scan_pv1_switch",
+        entity_category=EntityCategory.CONFIG,
+        device_class=SwitchDeviceClass.SWITCH,
+        setting="shadow_scan_pv1",
+    ),
+    GoodweSwitchEntityDescription(
+        key="shadow_scan_pv2_switch",
+        translation_key="shadow_scan_pv2_switch",
+        entity_category=EntityCategory.CONFIG,
+        device_class=SwitchDeviceClass.SWITCH,
+        setting="shadow_scan_pv2",
+    ),
+    GoodweSwitchEntityDescription(
+        key="shadow_scan_pv3_switch",
+        translation_key="shadow_scan_pv3_switch",
+        entity_category=EntityCategory.CONFIG,
+        device_class=SwitchDeviceClass.SWITCH,
+        setting="shadow_scan_pv3",
+    ),
 )
 
 

--- a/custom_components/goodwe/translations/en.json
+++ b/custom_components/goodwe/translations/en.json
@@ -31,7 +31,10 @@
             },
             "stop_inverter": {
                 "name": "Stop inverter"
-            }
+            },
+            "restart_inverter": {
+                "name": "Restart inverter"
+			}
         },
         "number": {
             "battery_discharge_depth": {
@@ -58,8 +61,11 @@
             "fast_charging_power": {
                 "name": "Fast charging power"
             },
-              "fast_charging_soc": {
+            "fast_charging_soc": {
                 "name": "Fast charging SoC"
+            },
+            "shadow_scan_time": {
+                "name": "Shadow Scan Time"
             }
         },
         "select": {
@@ -118,6 +124,15 @@
             },
             "dod_holding_switch": {
                 "name": "DOD holding"
+            },
+            "shadow_scan_pv1_switch": {
+                "name": "Shadow Scan PV1 switch"
+            },
+            "shadow_scan_pv2_switch": {
+                "name": "Shadow Scan PV2 switch"
+            },
+            "shadow_scan_pv3_switch": {
+                "name": "Shadow Scan PV3 switch"
             }
         }
     },


### PR DESCRIPTION
Hi @mletenay,

This is linked to the now merged changes into goodwe 0.4.10 from https://github.com/marcelblijleven/goodwe/pull/115

It contains the same changes as closed pull request https://github.com/mletenay/home-assistant-goodwe-inverter/pull/383 but now includes the corrections identified by @Koky05.

The changes are:

- Add Button to Restart Inverter, with associated icon, string, english title.
- Add Number to configure Shadow Scan Time / Duration using 'UnitOfTime' measurement, with associated icon, string, english title.
- Add Sensor 'meter_active_power' to _MAIN_SENSORS to allow for GM1000 series Smart Meter data.
- Add Sensor Entity Description "mA" using UnitOfElectricCurrent Milliampere for Leakage Current.
- Add 3x Switch entries for Shadow Scan PV1/PV2/PV3, with associated icon, string, english title.

Thank you.