### PR TITLE
Add smart charging switch and battery charge/discharge current limits

### DIFF
--- a/custom_components/goodwe/number.py
+++ b/custom_components/goodwe/number.py
@@ -218,7 +218,7 @@ NUMBERS = (
         mapper=lambda v: v,
         setter=lambda inv, val: inv.write_setting("battery_charge_current", val),
         filter=lambda inv: "battery_charge_current" in {s.id_ for s in inv.settings()},
-        max_setting="bms_bat_charge_i_max",
+        max_setting="bms2_bat_charge_i_max",
     ),
     GoodweNumberEntityDescription(
         key="battery_discharge_current",
@@ -234,7 +234,7 @@ NUMBERS = (
         mapper=lambda v: v,
         setter=lambda inv, val: inv.write_setting("battery_discharge_current", val),
         filter=lambda inv: "battery_discharge_current" in {s.id_ for s in inv.settings()},
-        max_setting="bms_bat_discharge_i_max",
+        max_setting="bms2_bat_discharge_i_max",
     ),
 )
 

--- a/custom_components/goodwe/number.py
+++ b/custom_components/goodwe/number.py
@@ -272,7 +272,7 @@ async def async_setup_entry(
             try:
                 bms_max = await inverter.read_setting(description.max_setting)
                 if bms_max and bms_max > 0:
-                    entity.native_max_value = float(bms_max)
+                    entity._attr_native_max_value = float(bms_max)
             except (InverterError, ValueError):
                 pass
         entities.append(entity)
@@ -286,7 +286,6 @@ class InverterNumberEntity(NumberEntity):
     _attr_should_poll = False
     _attr_has_entity_name = True
     entity_description: GoodweNumberEntityDescription
-    native_max_value: float
 
     def __init__(
         self,
@@ -301,7 +300,6 @@ class InverterNumberEntity(NumberEntity):
         self._attr_device_info = device_info
         self._attr_native_value = float(current_value)
         self._inverter: Inverter = inverter
-        self.native_max_value = float(description.native_max_value or 100)
 
     async def async_update(self) -> None:
         """Get the current value from inverter."""

--- a/custom_components/goodwe/number.py
+++ b/custom_components/goodwe/number.py
@@ -36,6 +36,9 @@ class GoodweNumberEntityDescription(NumberEntityDescription):
     mapper: Callable[[any], int]
     setter: Callable[[Inverter, int], Awaitable[None]]
     filter: Callable[[Inverter], bool]
+    # When set, the inverter setting named here is read at setup time and used
+    # as native_max_value (falls back to the descriptor's native_max_value).
+    max_setting: str | None = None
 
 
 def _get_setting_unit(inverter: Inverter, setting: str) -> str:
@@ -215,6 +218,7 @@ NUMBERS = (
         mapper=lambda v: v,
         setter=lambda inv, val: inv.write_setting("battery_charge_current", val),
         filter=lambda inv: "battery_charge_current" in {s.id_ for s in inv.settings()},
+        max_setting="bms_bat_charge_i_max",
     ),
     GoodweNumberEntityDescription(
         key="battery_discharge_current",
@@ -230,6 +234,7 @@ NUMBERS = (
         mapper=lambda v: v,
         setter=lambda inv, val: inv.write_setting("battery_discharge_current", val),
         filter=lambda inv: "battery_discharge_current" in {s.id_ for s in inv.settings()},
+        max_setting="bms_bat_discharge_i_max",
     ),
 )
 
@@ -262,6 +267,14 @@ async def async_setup_entry(
             entity.native_max_value = (
                 inverter.rated_power * 2 if inverter.rated_power else 10000
             )
+        # Set the max value from a BMS-reported setting when available
+        if description.max_setting:
+            try:
+                bms_max = await inverter.read_setting(description.max_setting)
+                if bms_max and bms_max > 0:
+                    entity.native_max_value = float(bms_max)
+            except (InverterError, ValueError):
+                pass
         entities.append(entity)
 
     async_add_entities(entities)
@@ -273,6 +286,7 @@ class InverterNumberEntity(NumberEntity):
     _attr_should_poll = False
     _attr_has_entity_name = True
     entity_description: GoodweNumberEntityDescription
+    native_max_value: float
 
     def __init__(
         self,
@@ -287,6 +301,7 @@ class InverterNumberEntity(NumberEntity):
         self._attr_device_info = device_info
         self._attr_native_value = float(current_value)
         self._inverter: Inverter = inverter
+        self.native_max_value = float(description.native_max_value or 100)
 
     async def async_update(self) -> None:
         """Get the current value from inverter."""

--- a/custom_components/goodwe/number.py
+++ b/custom_components/goodwe/number.py
@@ -12,7 +12,12 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
 )
-from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfPower
+from homeassistant.const import (
+    PERCENTAGE,
+    EntityCategory,
+    UnitOfElectricCurrent,
+    UnitOfPower,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -195,6 +200,36 @@ NUMBERS = (
         mapper=lambda v: v,
         setter=lambda inv, val: inv.write_setting("battery_soc_protection", val),
         filter=lambda inv: True,
+    ),
+    GoodweNumberEntityDescription(
+        key="battery_charge_current",
+        translation_key="battery_charge_current",
+        icon="mdi:battery-arrow-up",
+        entity_category=EntityCategory.CONFIG,
+        device_class=NumberDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        native_step=1,
+        native_min_value=0,
+        native_max_value=100,
+        getter=lambda inv: inv.read_setting("battery_charge_current"),
+        mapper=lambda v: v,
+        setter=lambda inv, val: inv.write_setting("battery_charge_current", val),
+        filter=lambda inv: "battery_charge_current" in {s.id_ for s in inv.settings()},
+    ),
+    GoodweNumberEntityDescription(
+        key="battery_discharge_current",
+        translation_key="battery_discharge_current",
+        icon="mdi:battery-arrow-down",
+        entity_category=EntityCategory.CONFIG,
+        device_class=NumberDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        native_step=1,
+        native_min_value=0,
+        native_max_value=100,
+        getter=lambda inv: inv.read_setting("battery_discharge_current"),
+        mapper=lambda v: v,
+        setter=lambda inv, val: inv.write_setting("battery_discharge_current", val),
+        filter=lambda inv: "battery_discharge_current" in {s.id_ for s in inv.settings()},
     ),
 )
 

--- a/custom_components/goodwe/strings.json
+++ b/custom_components/goodwe/strings.json
@@ -55,6 +55,12 @@
       },
       "soc_upper_limit": {
         "name": "SoC upper limit"
+      },
+      "battery_charge_current": {
+        "name": "Battery charge current limit"
+      },
+      "battery_discharge_current": {
+        "name": "Battery discharge current limit"
       }
     },
     "select": {
@@ -103,6 +109,9 @@
       },
       "load_control": {
         "name": "Load control"
+      },
+      "smart_charging_enable": {
+        "name": "Smart charging (grid import)"
       }
     }
   },

--- a/custom_components/goodwe/switch.py
+++ b/custom_components/goodwe/switch.py
@@ -64,6 +64,13 @@ SWITCHES = (
         device_class=SwitchDeviceClass.SWITCH,
         setting="dod_holding",
     ),
+    GoodweSwitchEntityDescription(
+        key="smart_charging_enable",
+        translation_key="smart_charging_enable",
+        entity_category=EntityCategory.CONFIG,
+        device_class=SwitchDeviceClass.SWITCH,
+        setting="smart_charging_enable",
+    ),
 )
 
 


### PR DESCRIPTION
## Summary

- **New switch**: `smart_charging_enable` — exposes the \"Allow Grid import for charging if solar is insufficient\" setting (register 47609) that is configurable in the SEMS portal but was previously invisible in HA. Follows the same pattern as the existing `dod_holding_switch` and `fast_charging_switch` entries.
- **New numbers**: `battery_charge_current` and `battery_discharge_current` — expose the per-inverter charge/discharge current limits in Amperes. Both use a `filter` guard so they are only created when the inverter actually exposes these settings (e.g. ET/ES families), preventing errors on unsupported models.

## Test plan

- [ ] Reload GoodWe integration on an ET/ES inverter and verify `switch.goodwe_smart_charging_enable` appears under Configuration entities
- [ ] Toggle the switch and confirm the value changes at the inverter (readable via `read_setting("smart_charging_enable")`)
- [ ] Verify `number.goodwe_battery_charge_current` and `number.goodwe_battery_discharge_current` appear with correct A values
- [ ] Confirm entities are absent on inverter models that do not expose these settings (no errors in logs)